### PR TITLE
[RSpec-Rails onboarding] Include shoulda matchers and capybara

### DIFF
--- a/docs/rails/on_boarding/02_rspec/chapter_II.md
+++ b/docs/rails/on_boarding/02_rspec/chapter_II.md
@@ -64,3 +64,9 @@ end
 Add a validation to the method `publish_if_live` in the Book model which ensures that no publications can be made during the weekends.
 
 Create the necessary specs you seem fit to test this functionality.
+
+## Shoulda Matchers
+
+[Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) provides RSpec- one-liners to test common Rails functionality. It helps to eliminate long line of code to make it more straight forward and readable.
+
+With this in mind use shoulda matchers for any specs you seem fit.

--- a/docs/rails/on_boarding/02_rspec/chapter_IV.md
+++ b/docs/rails/on_boarding/02_rspec/chapter_IV.md
@@ -1,0 +1,10 @@
+# Chapter IV
+`(avr. time for this chapter: TBD)`
+
+While unit tests verify the correctness of individual units of code in isolation, integration tests ensure that these units work correctly when combined.
+
+## Capybara
+
+In the context of RSpec, integration tests are facilitated through tools like [Capybara](https://github.com/teamcapybara/capybara), which allows for simulating user interactions with the application's web interface.
+
+Create any tests that make sense to test the possible flows.


### PR DESCRIPTION
In this PR we are extending the RSpec onboarding to include shoulda matchers in Chapter II and capybara in Chapter IV.